### PR TITLE
Disambiguate between two kinds of line continuations

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -248,13 +248,17 @@ module.exports = grammar({
       seq(
         $.shell_fragment,
         repeat(
-          seq($.line_continuation, repeat($._comment_line), $.shell_fragment)
+          seq(
+            alias($.required_line_continuation, $.line_continuation),
+            repeat($._comment_line), $.shell_fragment
+          )
         )
       ),
 
     shell_fragment: ($) => repeat1(choice(/[^\\\[\n#\s][^\\\n]*/, /\\[^\n]/)),
 
     line_continuation: ($) => "\\\n",
+    required_line_continuation: ($) => "\\\n",
 
     _comment_line: ($) => seq(alias($._anon_comment, $.comment), "\n"),
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -142,7 +142,7 @@ enum {
   aux_sym_unquoted_string_repeat1 = 123,
 };
 
-static const char *ts_symbol_names[] = {
+static const char * const ts_symbol_names[] = {
   [ts_builtin_sym_end] = "end",
   [anon_sym_LF] = "\n",
   [aux_sym_from_instruction_token1] = "FROM",
@@ -269,7 +269,7 @@ static const char *ts_symbol_names[] = {
   [aux_sym_unquoted_string_repeat1] = "unquoted_string_repeat1",
 };
 
-static TSSymbol ts_symbol_map[] = {
+static const TSSymbol ts_symbol_map[] = {
   [ts_builtin_sym_end] = ts_builtin_sym_end,
   [anon_sym_LF] = anon_sym_LF,
   [aux_sym_from_instruction_token1] = aux_sym_from_instruction_token1,
@@ -907,7 +907,7 @@ enum {
   field_value = 9,
 };
 
-static const char *ts_field_names[] = {
+static const char * const ts_field_names[] = {
   [0] = NULL,
   [field_as] = "as",
   [field_default] = "default",
@@ -978,7 +978,7 @@ static const TSFieldMapEntry ts_field_map_entries[] = {
     {field_as, 4},
 };
 
-static TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
+static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
   [0] = {0},
   [3] = {
     [1] = sym_unquoted_string,
@@ -989,7 +989,7 @@ static TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGT
   },
 };
 
-static uint16_t ts_non_terminal_alias_map[] = {
+static const uint16_t ts_non_terminal_alias_map[] = {
   aux_sym__user_name_or_group, 2,
     aux_sym__user_name_or_group,
     sym_unquoted_string,
@@ -2563,7 +2563,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   }
 }
 
-static TSLexMode ts_lex_modes[STATE_COUNT] = {
+static const TSLexMode ts_lex_modes[STATE_COUNT] = {
   [0] = {.lex_state = 0},
   [1] = {.lex_state = 158},
   [2] = {.lex_state = 158},
@@ -2794,7 +2794,7 @@ static TSLexMode ts_lex_modes[STATE_COUNT] = {
   [227] = {.lex_state = 50},
 };
 
-static uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
+static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   [0] = {
     [ts_builtin_sym_end] = ACTIONS(1),
     [anon_sym_COLON] = ACTIONS(1),
@@ -2861,7 +2861,7 @@ static uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
   },
 };
 
-static uint16_t ts_small_parse_table[] = {
+static const uint16_t ts_small_parse_table[] = {
   [0] = 24,
     ACTIONS(3), 1,
       sym_line_continuation,
@@ -5039,7 +5039,7 @@ static uint16_t ts_small_parse_table[] = {
       aux_sym_param_token1,
 };
 
-static uint32_t ts_small_parse_table_map[] = {
+static const uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(2)] = 0,
   [SMALL_STATE(3)] = 92,
   [SMALL_STATE(4)] = 184,
@@ -5268,7 +5268,7 @@ static uint32_t ts_small_parse_table_map[] = {
   [SMALL_STATE(227)] = 3025,
 };
 
-static TSParseActionEntry ts_parse_actions[] = {
+static const TSParseActionEntry ts_parse_actions[] = {
   [0] = {.entry = {.count = 0, .reusable = false}},
   [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
   [3] = {.entry = {.count = 1, .reusable = true}}, SHIFT_EXTRA(),
@@ -5632,7 +5632,7 @@ extern "C" {
 #endif
 
 extern const TSLanguage *tree_sitter_dockerfile(void) {
-  static TSLanguage language = {
+  static const TSLanguage language = {
     .version = LANGUAGE_VERSION,
     .symbol_count = SYMBOL_COUNT,
     .alias_count = ALIAS_COUNT,
@@ -5643,18 +5643,18 @@ extern const TSLanguage *tree_sitter_dockerfile(void) {
     .production_id_count = PRODUCTION_ID_COUNT,
     .field_count = FIELD_COUNT,
     .max_alias_sequence_length = MAX_ALIAS_SEQUENCE_LENGTH,
-    .parse_table = (const uint16_t *)ts_parse_table,
-    .small_parse_table = (const uint16_t *)ts_small_parse_table,
-    .small_parse_table_map = (const uint32_t *)ts_small_parse_table_map,
+    .parse_table = &ts_parse_table[0][0],
+    .small_parse_table = ts_small_parse_table,
+    .small_parse_table_map = ts_small_parse_table_map,
     .parse_actions = ts_parse_actions,
     .symbol_names = ts_symbol_names,
     .field_names = ts_field_names,
-    .field_map_slices = (const TSFieldMapSlice *)ts_field_map_slices,
-    .field_map_entries = (const TSFieldMapEntry *)ts_field_map_entries,
+    .field_map_slices = ts_field_map_slices,
+    .field_map_entries = ts_field_map_entries,
     .symbol_metadata = ts_symbol_metadata,
     .public_symbol_map = ts_symbol_map,
     .alias_map = ts_non_terminal_alias_map,
-    .alias_sequences = (const TSSymbol *)ts_alias_sequences,
+    .alias_sequences = &ts_alias_sequences[0][0],
     .lex_modes = ts_lex_modes,
     .lex_fn = ts_lex,
   };

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -102,8 +102,8 @@ struct TSLanguage {
   const uint16_t *small_parse_table;
   const uint32_t *small_parse_table_map;
   const TSParseActionEntry *parse_actions;
-  const char **symbol_names;
-  const char **field_names;
+  const char * const *symbol_names;
+  const char * const *field_names;
   const TSFieldMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;


### PR DESCRIPTION
Hi,

I'm the lead author of [ocaml-tree-sitter](https://github.com/returntocorp/ocaml-tree-sitter-core) and I'm working on supporting dockerfile syntax in [semgrep](https://github.com/returntocorp/semgrep). I ran into an issue that doesn't pose a problem to the tree-sitter parser itself but creates an ambiguity that prevents ocaml-tree-sitter from working.

This PR introduces a new name for the line continuations that appear explicitly in the `shell_command` rule, distinguishing it from the line continuations that can occur anywhere as declared by the `extras` field. This makes ocaml-tree-sitter happy, allowing [the recovery of a fully typed tree](https://github.com/returntocorp/ocaml-tree-sitter-core/blob/main/doc/parsing.md).

https://github.com/returntocorp/ocaml-tree-sitter-core/pull/20 is related to this.
