### PR TITLE
Prevent '--platform=xxx' after 'FROM' from being mistaken for the image name

### DIFF
--- a/corpus/from.txt
+++ b/corpus/from.txt
@@ -71,3 +71,18 @@ FROM sourcegraph/alpine:3.12@sha256:ce099fbcd3cf70b338fc4cb2a4e1fa9ae847de21afdb
 		    digest: (image_digest))
 		as: (image_alias)))
 
+==================
+From with param
+==================
+
+FROM --platform=linux/arm64 alpine-${VERSION}-z
+
+---
+
+(source_file
+  (from_instruction
+    (param)
+    (image_spec
+      (image_name
+        (expansion
+          (variable))))))

--- a/grammar.js
+++ b/grammar.js
@@ -212,7 +212,7 @@ module.exports = grammar({
       ),
 
     image_name: ($) => seq(
-      choice(/[^@:\s\$-][^@:\s\$]*/, $.expansion),
+      choice(/[^@:\s\$-]/, $.expansion),
       repeat(choice(/[^@:\s\$]+/, $.expansion))
     ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -211,7 +211,10 @@ module.exports = grammar({
         )
       ),
 
-    image_name: ($) => repeat1(choice(/[^@:\s\$]+/, $.expansion)),
+    image_name: ($) => seq(
+      choice(/[^@:\s\$-][^@:\s\$]*/, $.expansion),
+      repeat(choice(/[^@:\s\$]+/, $.expansion))
+    ),
 
     image_tag: ($) =>
       seq(


### PR DESCRIPTION
I suspect the problem was that `--` (first token in `param`) is shorter than `--platform=xxx` (first token of `image_name`) and therefore the latter was preferred by the lexer, resulting in `--platform=xxx` being treated as an image name. I solved this by excluding `-` for the leading character of an image name. I hope this is ok - let me know if you know of a more complete spec than https://docs.docker.com/engine/reference/builder/#from .